### PR TITLE
launcher_start fric

### DIFF
--- a/Launcher.hpp
+++ b/Launcher.hpp
@@ -544,7 +544,7 @@ class Launcher : public LibXR::Application {
     bool success = (shot_.fric_drop_max > launcher::param::MIN_FRICDROP) &&
                    (motor_trig_->GetOmega() >
                     0.88 * M_2PI * trig_freq_ / param_.num_trig_tooth);
-
+                    
     shot_.active = false;
     if (success) {
       heat_limit_.launched_num++;


### PR DESCRIPTION
change fric_control and add slow start and slow stop.
Fixes QDU-Robomaster/QDU-Robomaster-Roadmap#22

## Summary by Sourcery

Refine launcher control logic with state-based fric and trigger handling, including slow start/stop behavior and jam recovery for the trigger mechanism.

New Features:
- Introduce a centralized launcher state machine to manage STOP, NORMAL, OVERHEAT, and JAMMED behaviors based on motor status and fire commands.
- Add jam detection and automatic reversal logic for the trigger mechanism when excessive current and low speed are detected.
- Implement smoothed (low-pass filtered) control of friction wheel RPMs for gradual spin-up and spin-down in different fric modes.

Enhancements:
- Replace separate trigger mode selection and target calculation routines with integrated trigger control that supports relax, safe, single, continuous, and jam modes.
- Track trigger frequency and angles to better coordinate single and continuous firing behavior.
- Extend launcher parameters and internal state to support the new control flow and filtering without changing external interfaces.