### PR TITLE
HeroLauncher添加SET_MODE_RELAX适配Launcher

### DIFF
--- a/HeroLauncher.hpp
+++ b/HeroLauncher.hpp
@@ -395,7 +395,7 @@ class HeroLauncher {
     heat_ctrl_.cooling_rate = referee_data_.cooling_rate;
     heat_ctrl_.cooling_rate = 1000;  // for debug
     heat_ctrl_.heat -=
-        heat_ctrl_.cooling_rate / 500.0;  // 每个控制周期的冷却恢复
+        heat_ctrl_.cooling_rate / 500.0f;  // 每个控制周期的冷却恢复
     if (fired_ >= 1) {
       heat_ctrl_.heat += heat_ctrl_.heat_increase;
       fired_ = 0;


### PR DESCRIPTION
Fixes QDU-Robomaster/QDU-Robomaster-Roadmap#43

## Summary by Sourcery

Adjust HeroLauncher operating defaults and add a relaxed friction mode for better launcher behavior.

Enhancements:
- Introduce a RELAX friction mode in the HeroLauncher FRICMODE enum to support a relaxed operating state.
- Lower the HeroLauncher worker thread priority from HIGH to MEDIUM to better balance system scheduling.
- Change the initial first-loading state to start enabled by default for the HeroLauncher.