### PR TITLE
HeroLauncher添加SET_MODE_RELAX

### DIFF
--- a/Launcher.hpp
+++ b/Launcher.hpp
@@ -103,9 +103,6 @@ class Launcher : public LibXR::Application {
     float fric1_setpoint_speed;
     /*二级摩擦轮转速*/
     float fric2_setpoint_speed;
-/*默认弹速*/
-    float default_bullet_speed;
-    float fric_radius;
     float trig_gear_ratio;
     uint8_t num_trig_tooth;
     /*弹频*/


### PR DESCRIPTION
添加SET_MODE_RELAX，移除了LauncherParam中的无用变量，添加了TRIG_ZERO_ANGLE_OFFSET和TRIG_LOADING_ANGLE_STEP宏定义

## Summary by Sourcery

Add a relaxed friction wheel mode, simplify launcher parameters, and introduce macros for trigger angle calibration and step size.

New Features:
- Introduce a RELAX mode to the friction wheel mode enumeration for the hero launcher.
- Add TRIG_ZERO_ANGLE_OFFSET and TRIG_LOADING_ANGLE_STEP macros to standardize trigger angle offsets and step sizes.

Enhancements:
- Remove unused default bullet speed and friction radius parameters from launcher configuration structures.
- Adjust hero launcher control thread to run at medium priority instead of high.
- Make initial first-loading state enabled by default and use parameterized tooth count for trigger rotation steps.
- Improve numeric consistency by using float literals in heat cooling calculations.