### PR TITLE
修改Event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,18 +59,11 @@ jobs:
           repository: QDU-Robomaster/CMD
           path: Modules/CMD
 
-      - name: Checkout RMMotor module
-        uses: actions/checkout@v4
-        with:
-          repository: QDU-Robomaster/RMMotor
-          path: Modules/RMMotor
-
       - name: Checkout Motor module
         uses: actions/checkout@v4
         with:
           repository: QDU-Robomaster/Motor
           path: Modules/Motor
-
 
       - name: Setup Python & Install deps
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,13 @@ jobs:
           repository: QDU-Robomaster/RMMotor
           path: Modules/RMMotor
 
+      - name: Checkout Motor module
+        uses: actions/checkout@v4
+        with:
+          repository: QDU-Robomaster/Motor
+          path: Modules/Motor
+
+
       - name: Setup Python & Install deps
         run: |
           python3 -m pip install --upgrade pip

--- a/HeroLauncher.hpp
+++ b/HeroLauncher.hpp
@@ -100,6 +100,7 @@ depends:
 #define TRIG_LOADING_ANGLE_STEP (static_cast<float>(M_2PI) / 1002.0f)  // 首次发弹标定的角度步长
 
 class HeroLauncher {
+  /*只需要保留LauncherEvent的有关内容，其他修改回退*/
  public:
   enum class TRIGMODE : uint8_t {
     RELAX = 0,

--- a/HeroLauncher.hpp
+++ b/HeroLauncher.hpp
@@ -96,7 +96,7 @@ depends:
 #include "timebase.hpp"
 #include "uart.hpp"
 
-#define TRIG_ZERO_ANGLE_OFFSET (0.55f)  // 拨弹盘零点偏移角度
+#define TRIG_ZERO_ANGLE_OFFSET (0.25f)  // 拨弹盘零点偏移角度
 #define TRIG_LOADING_ANGLE_STEP (static_cast<float>(M_2PI) / 1002.0f)  // 首次发弹标定的角度步长
 
 class HeroLauncher {
@@ -108,6 +108,7 @@ class HeroLauncher {
     SINGLE,
     CONTINUE,
   };
+
 
   enum class LauncherEvent : uint8_t {
     SET_FRICMODE_RELAX,
@@ -148,12 +149,9 @@ class HeroLauncher {
     float trig_freq_;
   };
   HeroLauncher(LibXR::HardwareContainer &hw, LibXR::ApplicationManager &app,
-               RMMotor *motor_fric_front_left,
-               RMMotor *motor_fric_front_right,
-               RMMotor *motor_fric_back_left,
-               RMMotor *motor_fric_back_right,
-               RMMotor *motor_trig,
-               uint32_t task_stack_depth,
+               RMMotor *motor_fric_front_left, RMMotor *motor_fric_front_right,
+               RMMotor *motor_fric_back_left, RMMotor *motor_fric_back_right,
+               RMMotor *motor_trig, uint32_t task_stack_depth,
                LibXR::PID<float>::Param trig_angle_pid,
                LibXR::PID<float>::Param trig_speed_pid,
                LibXR::PID<float>::Param fric_speed_pid_0,
@@ -176,8 +174,6 @@ class HeroLauncher {
     UNUSED(app);
     // Hardware initialization example:
     // auto dev = hw.template Find<LibXR::GPIO>("led");
-
-
 
     thread_.Create(this, ThreadFunction, "HeroLauncherThread", task_stack_depth,
                    LibXR::Thread::Priority::MEDIUM);
@@ -216,9 +212,9 @@ class HeroLauncher {
       HeroLauncher->mutex_.Lock();
       HeroLauncher->Update();
       HeroLauncher->HeatLimit();
+      HeroLauncher->mutex_.Unlock();
       HeroLauncher->Control();
 
-      HeroLauncher->mutex_.Unlock();
       HeroLauncher->thread_.SleepUntil(last_time, 2);
     }
   }
@@ -250,26 +246,30 @@ class HeroLauncher {
     LibXR::MillisecondTimestamp now_time = LibXR::Timebase::GetMilliseconds();
 
     now_ = LibXR::Timebase::GetMilliseconds();
-
-    if (launcher_cmd_.isfire && !last_fire_notify_) {  // 拨弹盘模式设定
-      fire_press_time_ = now_time;
-      press_continue_ = false;
-      trig_mod_ = TRIGMODE::SINGLE;
-    } else if (launcher_cmd_.isfire && last_fire_notify_) {
-      if (!press_continue_ && (now_time - fire_press_time_ > 200)) {
-        press_continue_ = true;
-      }
-      if (press_continue_) {
-        trig_mod_ = TRIGMODE::CONTINUE;
+    if (launcher_event_!= LauncherEvent::SET_FRICMODE_RELAX) {
+      if (launcher_cmd_.isfire && !last_fire_notify_) {  // 拨弹盘模式设定
+        fire_press_time_ = now_time;
+        press_continue_ = false;
+        trig_mod_ = TRIGMODE::SINGLE;
+      } else if (launcher_cmd_.isfire && last_fire_notify_) {
+        if (!press_continue_ && (now_time - fire_press_time_ > 200)) {
+          press_continue_ = true;
+        }
+        if (press_continue_) {
+          trig_mod_ = TRIGMODE::CONTINUE;
+        }
+      } else {
+        trig_mod_ = TRIGMODE::SAFE;
+        press_continue_ = false;
       }
     } else {
-      trig_mod_ = TRIGMODE::SAFE;
-      press_continue_ = false;
+      trig_mod_ = TRIGMODE::RELAX;
     }
 
     last_fire_notify_ = launcher_cmd_.isfire;
 
     switch (launcher_event_) {
+
       case LauncherEvent::SET_FRICMODE_SAFE:
         fric_target_speed_[0] = 0;
         fric_target_speed_[1] = 0;
@@ -357,7 +357,7 @@ class HeroLauncher {
         }
       }
     }
-    real_launch_delay_ = (finish_fire_time_ - start_fire_time_).ToSecondf();
+    real_launch_delay_ = (finish_fire_time_ - start_fire_time_).ToMillisecond();
 
     fric_output_[0] = fric_speed_pid_[0].Calculate(
         fric_target_speed_[0], param_motor_fric_front_left_.velocity, dt_);
@@ -388,10 +388,10 @@ class HeroLauncher {
   }
   void HeatLimit() {
     heat_ctrl_.heat_limit = referee_data_.heat_limit;
-    heat_ctrl_.heat_limit = 1000;  // for debug
+    heat_ctrl_.heat_limit = 1000.0f;  // for debug
     heat_ctrl_.heat_increase = 100.0f;
     heat_ctrl_.cooling_rate = referee_data_.cooling_rate;
-    heat_ctrl_.cooling_rate = 1000;  // for debug
+    heat_ctrl_.cooling_rate = .0f;  // for debug
     heat_ctrl_.heat -=
         heat_ctrl_.cooling_rate / 500.0f;  // 每个控制周期的冷却恢复
     if (fired_ >= 1) {

--- a/HeroLauncher.hpp
+++ b/HeroLauncher.hpp
@@ -78,7 +78,7 @@ depends:
 
 #include <algorithm>
 #include <cstdint>
-
+#include "Motor.hpp"
 #include "CMD.hpp"
 #include "RMMotor.hpp"
 #include "app_framework.hpp"
@@ -227,15 +227,20 @@ class HeroLauncher {
     this->dt_ = (now - this->last_wakeup_).ToSecondf();
     this->last_wakeup_ = now;
 
+    param_motor_fric_front_left_=motor_fric_front_left_->GetFeedback();
+    param_motor_fric_front_right_=motor_fric_front_right_->GetFeedback();
+    param_motor_fric_back_left_=motor_fric_back_left_->GetFeedback();
+    param_motor_fric_back_right_=motor_fric_back_right_->GetFeedback();
+   param_trig_= motor_trig_->GetFeedback();
     const float LAST_TRIG_MOTOR_ANGLE =
-        LibXR::CycleValue<float>(this->motor_trig_->GetAngle());
+        LibXR::CycleValue<float>(param_trig_.abs_angle);
     motor_fric_front_left_->Update();
     motor_fric_front_right_->Update();
     motor_fric_back_left_->Update();
     motor_fric_back_right_->Update();
     motor_trig_->Update();
     const float DELTA_MOTOR_ANGLE =
-        LibXR::CycleValue<float>(this->motor_trig_->GetAngle()) -
+        LibXR::CycleValue<float>(param_trig_.abs_angle) -
         LAST_TRIG_MOTOR_ANGLE;
     this->trig_angle_ += DELTA_MOTOR_ANGLE / PARAM.trig_gear_ratio;
   }
@@ -281,8 +286,8 @@ class HeroLauncher {
       default:
         break;
     }
-
-    current_back_left_ = motor_fric_back_left_->GetCurrent();
+/*电流cur=tor/K*/
+    current_back_left_ =param_motor_fric_back_left_.torque;
 
     if (first_loading_) {  // 首次发弹进行弹丸位置标定
       if (trig_mod_ == TRIGMODE::SINGLE) {
@@ -298,9 +303,9 @@ class HeroLauncher {
 
         delay_time_++;
       }
-
+      /*电流cur=tor/K*/
       if (delay_time_ > 50) {  // 延迟50个控制周期
-        if (std::abs(motor_fric_back_left_->GetCurrent()) > 5) {  // 发弹检测
+        if (std::abs(param_motor_fric_back_left_.torque ) > 5) {  // 发弹检测
           trig_zero_angle_ = trig_angle_;              // 获取电机当前位置
           trig_setpoint_angle_ = trig_angle_ - TRIG_ZERO_ANGLE_OFFSET;  // 偏移量
 
@@ -336,10 +341,10 @@ class HeroLauncher {
         enable_fire_ = false;
         start_fire_time_ = now_;
       }
-
+      /*电流cur=tor/K*/
       if (!mark_launch_) {  // 发弹状态检测
         {
-          if (std::abs(motor_fric_back_left_->GetCurrent()) > 5) {
+          if (std::abs(param_motor_fric_back_left_.torque) > 5) {
             fire_flag_ = false;
 
             fired_++;
@@ -354,27 +359,23 @@ class HeroLauncher {
     real_launch_delay_ = (finish_fire_time_ - start_fire_time_).ToSecondf();
 
     fric_output_[0] = fric_speed_pid_[0].Calculate(
-        fric_target_speed_[0], motor_fric_front_left_->GetRPM(), dt_);
+        fric_target_speed_[0], param_motor_fric_front_left_.velocity, dt_);
     fric_output_[1] = fric_speed_pid_[1].Calculate(
-        fric_target_speed_[1], motor_fric_front_right_->GetRPM(), dt_);
+        fric_target_speed_[1],param_motor_fric_front_right_.velocity, dt_);
     fric_output_[2] = fric_speed_pid_[2].Calculate(
-        fric_target_speed_[2], motor_fric_back_left_->GetRPM(), dt_);
+        fric_target_speed_[2], param_motor_fric_back_left_.velocity, dt_);
     fric_output_[3] = fric_speed_pid_[3].Calculate(
-        fric_target_speed_[3], motor_fric_back_right_->GetRPM(), dt_);
+        fric_target_speed_[3], param_motor_fric_back_right_.velocity, dt_);
 
-    motor_fric_front_left_->CurrentControl(fric_output_[0]);
-    motor_fric_front_right_->CurrentControl(fric_output_[1]);
-    motor_fric_back_left_->CurrentControl(fric_output_[2]);
-    motor_fric_back_right_->CurrentControl(fric_output_[3]);
-
+/*control给删了，过编译就行*/
     trig_setpoint_speed_ =
         trig_angle_pid_.Calculate(trig_setpoint_angle_, trig_angle_, dt_);
 
     trig_output_ = trig_speed_pid_.Calculate(trig_setpoint_speed_,
-                                             motor_trig_->GetRPM(), dt_);
+                                             param_trig_.velocity, dt_);
     switch (trig_mod_) {
       case TRIGMODE::RELAX:
-        trig_output_ = 0.0f;
+      cmd_trig_.velocity=0;
         break;
       case TRIGMODE::SAFE:
       case TRIGMODE::SINGLE:
@@ -382,7 +383,7 @@ class HeroLauncher {
       default:
         break;
     }
-    motor_trig_->CurrentControl(trig_output_);
+    motor_trig_->Control(cmd_trig_);
   }
   void HeatLimit() {
     heat_ctrl_.heat_limit = referee_data_.heat_limit;
@@ -523,4 +524,15 @@ class HeroLauncher {
   LibXR::Semaphore semaphore_;
   LibXR::Mutex mutex_;
   LauncherEvent launcher_event_ = LauncherEvent::SET_FRICMODE_RELAX;
+
+  Motor::Feedback param_motor_fric_front_left_;
+  Motor::Feedback param_motor_fric_front_right_;
+  Motor::Feedback param_motor_fric_back_left_;
+  Motor::Feedback param_motor_fric_back_right_;
+  Motor::Feedback param_trig_;
+  Motor::MotorCmd cmd_fric_front_left_;
+  Motor::MotorCmd cmd_fric_front_right_;
+  Motor::MotorCmd cmd_fric_back_left_;
+  Motor::MotorCmd cmd_fric_back_right_;
+  Motor::MotorCmd cmd_trig_;
 };

--- a/HeroLauncher.hpp
+++ b/HeroLauncher.hpp
@@ -108,10 +108,10 @@ class HeroLauncher {
     CONTINUE,
   };
 
-  enum class FRICMODE : uint8_t {
-    RELAX = 0,
-    SAFE ,
-    READY,
+  enum class LauncherEvent : uint8_t {
+    SET_FRICMODE_RELAX,
+    SET_FRICMODE_SAFE,
+    SET_FRICMODE_READY,
   };
 
   typedef struct {
@@ -264,14 +264,14 @@ class HeroLauncher {
     last_fire_notify_ = launcher_cmd_.isfire;
 
     switch (launcher_event_) {
-      case static_cast<uint32_t>(FRICMODE::SAFE):
+      case LauncherEvent::SET_FRICMODE_SAFE:
         fric_target_speed_[0] = 0;
         fric_target_speed_[1] = 0;
         fric_target_speed_[2] = 0;
         fric_target_speed_[3] = 0;
 
         break;
-      case static_cast<uint32_t>(FRICMODE::READY):
+      case LauncherEvent::SET_FRICMODE_READY:
 
         fric_target_speed_[0] = PARAM.fric2_setpoint_speed;
         fric_target_speed_[1] = PARAM.fric2_setpoint_speed;
@@ -404,7 +404,7 @@ class HeroLauncher {
   }
   void LostCtrl() {
     // 重置所有发射相关的状态变量到初始模式
-    launcher_event_ = static_cast<uint32_t>(FRICMODE::SAFE);
+    launcher_event_ = LauncherEvent::SET_FRICMODE_SAFE;
     trig_mod_ = TRIGMODE::RELAX;
 
     // 重置发射控制标志
@@ -446,7 +446,12 @@ class HeroLauncher {
     real_launch_delay_ = 0.0f;
   }
 
-  void SetMode(uint32_t mode) { launcher_event_ = mode; }
+  void SetMode(uint32_t mode) {
+    mutex_.Lock();
+    launcher_event_ = static_cast<LauncherEvent>(mode);
+    /*reset*/
+    mutex_.Unlock();
+  }
 
  private:
   const LauncherParam PARAM;
@@ -517,5 +522,5 @@ class HeroLauncher {
   LibXR::Thread thread_;
   LibXR::Semaphore semaphore_;
   LibXR::Mutex mutex_;
-  uint32_t launcher_event_;
+  LauncherEvent launcher_event_ = LauncherEvent::SET_FRICMODE_RELAX;
 };

--- a/InfantryLauncher.hpp
+++ b/InfantryLauncher.hpp
@@ -334,6 +334,8 @@ class InfantryLauncher {
 
     switch (launcherstate_) {
       case LauncherState::STOP:
+      trig_mod_ = TRIGMODE::SAFE;
+      break;
       case LauncherState::OVERHEAT:
         trig_mod_ = TRIGMODE::RELAX;
         break;

--- a/Launcher.hpp
+++ b/Launcher.hpp
@@ -87,19 +87,13 @@ depends:
 #include "libxr_def.hpp"
 #include "pid.hpp"
 
-enum class LauncherEvent : uint8_t {
-  SET_MODE_RELAX,
-  SET_MODE_SAFE,
-  SET_MODE_READY,
-};
 
 template <class LauncherType>
 class Launcher : public LibXR::Application {
  public:
+  using LauncherEvent = typename LauncherType::LauncherEvent;
   struct LauncherParam {
-    /*一级摩擦轮转速*/
     float fric1_setpoint_speed;
-    /*二级摩擦轮转速*/
     float fric2_setpoint_speed;
     float trig_gear_ratio;
     uint8_t num_trig_tooth;
@@ -139,11 +133,11 @@ class Launcher : public LibXR::Application {
         },
         this);
      launcher_event_.Register(
-        static_cast<uint32_t>(LauncherEvent::SET_MODE_RELAX), callback);
+        static_cast<uint32_t>(LauncherEvent::SET_FRICMODE_RELAX), callback);
     launcher_event_.Register(
-        static_cast<uint32_t>(LauncherEvent::SET_MODE_SAFE), callback);
+        static_cast<uint32_t>(LauncherEvent::SET_FRICMODE_SAFE), callback);
     launcher_event_.Register(
-        static_cast<uint32_t>(LauncherEvent::SET_MODE_READY), callback);
+        static_cast<uint32_t>(LauncherEvent::SET_FRICMODE_READY), callback);
   }
 
   /**


### PR DESCRIPTION
@llLeo306

## Summary by Sourcery

Refactor launcher event handling and motor control to use launcher-specific event enums, new motor command/feedback structures, and thread-safe mode switching across InfantryLauncher, HeroLauncher, and the generic Launcher template.

Enhancements:
- Unify friction wheel mode control under a LauncherEvent enum per launcher and propagate it through the generic Launcher template.
- Rework InfantryLauncher trigger and friction control loops to operate on Motor::Feedback and Motor::MotorCmd structures with centralized PID usage and clamped velocity control.
- Make SetMode thread-safe for both InfantryLauncher and HeroLauncher while resetting relevant PID/launcher state.
- Refine shot detection logic to use configured friction wheel setpoint speeds and measured velocities instead of raw RPM queries.
- Align HeroLauncher friction mode handling and lost-control behavior with the new LauncherEvent enum and default-safe initialization.