### PR TITLE
删掉热量控制，修改一些其他内容以提供小弹丸的车使用

### DIFF
--- a/InfantryLauncher.hpp
+++ b/InfantryLauncher.hpp
@@ -34,6 +34,7 @@ constexpr float TRIGSTEP = static_cast<float>(M_2PI) / 10;
 }  // namespace launcher::param
 
 class InfantryLauncher {
+  /* pid修改建议：改弹频的同时吧pid_trig_angle的out_limit修改为和弹频差不多，这样实际弹频就会接近理想弹频*/
  public:
   enum class LauncherState : uint8_t {
     STOP,
@@ -171,10 +172,6 @@ class InfantryLauncher {
    *
    */
   void Update() {
-    referee_data_.heat_limit = 260.0f;
-    referee_data_.heat_cooling = 30.0f;
-    heat_limit_.single_heat = 10.0f;
-    heat_limit_.heat_threshold = 200.0f;
 
     static float last_motor_angle = 0.0f;
     static bool initialized = false;
@@ -243,7 +240,6 @@ if (fric_mod_ != FRICMODE::READY) {
       default:
         break;
     }
-    last_fric_mod_ = fric_mod_;
   }
 
   void SetTrig() {
@@ -343,12 +339,9 @@ if (fric_mod_ != FRICMODE::READY) {
  private:
   LauncherState launcherstate_ = LauncherState::STOP;
   LauncherParam param_;
-  RefereeData referee_data_;
-  HeatLimit heat_limit_;
   TRIGMODE last_trig_mod_ = TRIGMODE::RELAX;
   TRIGMODE trig_mod_ = TRIGMODE::RELAX;
   FRICMODE fric_mod_ = FRICMODE::RELAX;
-  FRICMODE last_fric_mod_ = FRICMODE::RELAX;
 
   float target_trig_angle_ = 0.0f;
   float trig_angle_ = 0.0f;
@@ -379,12 +372,6 @@ if (fric_mod_ != FRICMODE::READY) {
   LibXR::Semaphore semaphore_;
   LibXR::Mutex mutex_;
   uint32_t launcher_event_;
-  struct ShotJudge {
-    bool active = false;
-    float t = 0.0f;
-  };
-
-  ShotJudge shot_;
 
   float fric_out_left_ = 0.0f;
   float fric_out_right_ = 0.0f;

--- a/Launcher.hpp
+++ b/Launcher.hpp
@@ -9,19 +9,19 @@ constructor_args:
   - motor_fric_back_left: '@&motor_fric_back_left'
   - motor_fric_back_right: '@&motor_fric_back_right'
   - motor_trig: '@&motor_trig'
-  - task_stack_depth: 4096
+  - task_stack_depth: 2048
   - pid_trig_angle:
       k: 1.0
-      p: 4000.0
+      p: 35.0
       i: 0.0
       d: 0.0
       i_limit: 0.0
-      out_limit: 4000.0
+      out_limit: 10.0
       cycle: false
   - pid_trig_speed:
       k: 1.0
-      p: 0.0012
-      i: 0.0005
+      p: 0.04
+      i: 0.04
       d: 0.0
       i_limit: 1.0
       out_limit: 1.0
@@ -44,7 +44,7 @@ constructor_args:
       cycle: false
   - pid_fric_speed_2:
       k: 1.0
-      p: 0.002
+      p: 0.00
       i: 0.0
       d: 0.0
       i_limit: 0.0
@@ -52,21 +52,21 @@ constructor_args:
       cycle: false
   - pid_fric_speed_3:
       k: 1.0
-      p: 0.002
+      p: 0.00
       i: 0.0
       d: 0.0
       i_limit: 0.0
       out_limit: 1.0
       cycle: false
   - launcher_param:
-      fric1_setpoint_speed: 4950.0
-      fric2_setpoint_speed: 3820.0
-      trig_gear_ratio: 19.2032
-      num_trig_tooth: 6
+      fric1_setpoint_speed: 600.0
+      fric2_setpoint_speed: 0.0
+      trig_gear_ratio: 36.0
+      num_trig_tooth: 10
       trig_freq_: 0.0
   - cmd: '@&cmd'
 template_args:
-  - LauncherType: HeroLauncher
+  - LauncherType: InfantryLauncher
 required_hardware:
   - dr16
   - can


### PR DESCRIPTION
@llLeo306

## Summary by Sourcery

Remove heat-based firing control and shot detection logic from the infantry launcher and retune it for a low-rate small-projectile platform.

Enhancements:
- Simplify launcher state handling by removing jam and overheat states tied to current and heat calculations.
- Drive trigger frequency control directly from launcher parameters and adjust PID clamping around the new trigger frequency behavior.
- Retune PID gains and limits for trigger angle, trigger speed, and friction wheels for the new launcher mechanical setup.
- Update launcher configuration to use InfantryLauncher with revised friction speeds, gear ratio, tooth count, and reduced task stack depth.