### PR TITLE
ci添加referee,herolauncher检测摩擦轮扭矩检测发弹

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,7 @@ jobs:
           xrobot_add_mod RMMotor --instance-id motor_fric_back_right
           xrobot_add_mod RMMotor --instance-id motor_trig
           xrobot_add_mod CMD --instance-id cmd
+          xrobot_add_mod Referee --instance-id referee
 
       - name: Add this repo module
         run: |

--- a/HeroLauncher.hpp
+++ b/HeroLauncher.hpp
@@ -101,10 +101,9 @@ depends:
  */
 class HeroLauncher {
  public:
-  static constexpr float TRIG_ZERO_ANGLE_OFFSET = 0.50f;
+  static constexpr float TRIG_ZERO_ANGLE_OFFSET = 0.55f;
   static constexpr float TRIG_LOADING_ANGLE_STEP =
-      static_cast<float>(M_2PI) / 1002.0f;
-  static constexpr float M3508_TORQUE_CONSTANT = 0.3f;
+      static_cast<float>(M_2PI) / 1000.0f;
 
   enum class TrigMode : uint8_t {
     RELAX = 0,
@@ -236,10 +235,6 @@ class HeroLauncher {
    * @details 拨弹控制、发弹检测和摩擦轮PID输出。
    */
   void Control() {
-    /*电流cur=tor/K*/
-    current_back_left_ =
-        param_motor_fric_back_left_.torque / M3508_TORQUE_CONSTANT;
-
     if (first_loading_) {
       FirstLoadingControl();
     } else {
@@ -464,8 +459,8 @@ class HeroLauncher {
             param_.fric1_setpoint_speed) {
           fric_speed_pid_[0].SetOutLimit(1.0f);
           fric_speed_pid_[1].SetOutLimit(1.0f);
-          fric_speed_pid_[2].SetOutLimit(0.8f);
-          fric_speed_pid_[3].SetOutLimit(0.8f);
+          fric_speed_pid_[2].SetOutLimit(1.0f);
+          fric_speed_pid_[3].SetOutLimit(1.0f);
         }
         break;
       default:
@@ -492,8 +487,8 @@ class HeroLauncher {
     }
 
     if (delay_time_ > 50) {  // 延迟50个控制周期
-      if (std::abs(param_motor_fric_back_left_.torque) / M3508_TORQUE_CONSTANT >
-          0.5) {                         // 发弹检测
+      if (std::abs(param_motor_fric_back_left_.torque) >
+          0.05) {                         // 发弹检测
         trig_zero_angle_ = trig_angle_;  // 获取电机当前位置
         trig_setpoint_angle_ = trig_angle_ - TRIG_ZERO_ANGLE_OFFSET;  // 偏移量
 
@@ -536,8 +531,8 @@ class HeroLauncher {
     }
 
     if (!mark_launch_) {  // 发弹状态检测
-      if (std::abs(param_motor_fric_back_left_.torque) / M3508_TORQUE_CONSTANT >
-          0.5) {
+      if (std::abs(param_motor_fric_back_left_.torque) >
+          0.05) {
         fire_flag_ = false;
 
         fired_++;


### PR DESCRIPTION
另外修改了一些参数

## Summary by Sourcery

Adjust HeroLauncher firing detection thresholds and CI configuration for the Hero module.

Bug Fixes:
- Update friction wheel torque-based firing detection thresholds to trigger on lower torque readings.

Enhancements:
- Retune trigger zero-angle offset and loading angle step for improved launch control behavior.
- Increase friction wheel PID output limits for additional control authority at high speeds.

Build:
- Register the Referee module in the GitHub Actions build workflow for HeroLauncher.